### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 include tox.ini
-include Dockerfile
 include *.txt
 include *.rst
 include *.yml


### PR DESCRIPTION
During installation, pip warns that the Dockerfile is missing. However docker is not needed, and the warning may sound scary.