### PR TITLE
New locking mechanism to allow concurrent eio instances

### DIFF
--- a/elevation/datasource.mk
+++ b/elevation/datasource.mk
@@ -43,6 +43,7 @@ info:
 
 clean:
 	find cache -size 0 -name "*.tif" -delete
+	$(RM) $(PRODUCT).*.vrt
 	$(RM) -r spool/*
 
 distclean: clean

--- a/elevation/datasource.mk
+++ b/elevation/datasource.mk
@@ -34,7 +34,7 @@ copy_vrt:
 
 clip: $(PRODUCT).vrt
 	gdal_translate -q -co TILED=YES -co COMPRESS=DEFLATE -co ZLEVEL=9 -co PREDICTOR=2 -projwin $(PROJWIN) $(PRODUCT).$(RUN_ID).vrt $(OUTPUT)
-	rm $(PRODUCT).$(RUN_ID).vrt
+	$(RM) $(PRODUCT).$(RUN_ID).vrt
 
 info:
 	@echo 'Product folder: $(shell pwd)'

--- a/elevation/datasource.mk
+++ b/elevation/datasource.mk
@@ -29,8 +29,12 @@ cache/%.tif: spool/%$(TILE_EXT)
 
 download: $(ENSURE_TILE_PATHS)
 
+copy_vrt:
+	cp $(PRODUCT).vrt $(PRODUCT).$(RUN_ID).vrt
+
 clip: $(PRODUCT).vrt
-	gdal_translate -q -co TILED=YES -co COMPRESS=DEFLATE -co ZLEVEL=9 -co PREDICTOR=2 -projwin $(PROJWIN) $(PRODUCT).vrt $(OUTPUT)
+	gdal_translate -q -co TILED=YES -co COMPRESS=DEFLATE -co ZLEVEL=9 -co PREDICTOR=2 -projwin $(PROJWIN) $(PRODUCT).$(RUN_ID).vrt $(OUTPUT)
+	rm $(PRODUCT).$(RUN_ID).vrt
 
 info:
 	@echo 'Product folder: $(shell pwd)'

--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -178,7 +178,7 @@ def clip(bounds, output=DEFAULT_OUTPUT, margin=MARGIN, **kwargs):
     run_id = uuid.uuid4().hex
     bounds = build_bounds(bounds, margin=margin)
     datasource_root = seed(bounds=bounds, run_id=run_id, **kwargs)
-    do_clip(datasource_root, bounds, output, run_id, **kwargs)
+    do_clip(datasource_root, bounds, output, run_id=run_id, **kwargs)
 
 
 def info(cache_dir=CACHE_DIR, product=DEFAULT_PRODUCT):

--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -21,7 +21,6 @@ import collections
 import math
 import os.path
 import pkgutil
-from fasteners import InterProcessLock
 
 import appdirs
 

--- a/elevation/util.py
+++ b/elevation/util.py
@@ -24,8 +24,10 @@ import subprocess
 
 import fasteners
 
+from contextlib import contextmanager
 
-LOCKFILE_NAME = '.folder_lock'
+
+FOLDER_LOCKFILE_NAME = '.folder_lock'
 
 
 def selfcheck(tools):
@@ -42,40 +44,48 @@ def selfcheck(tools):
     return '\n'.join(msg) if msg else 'Your system is ready.'
 
 
-def folder_try_lock(wrapped):
+@contextmanager
+def lock_tiles(datasource_root, tile_names):
+    locks = []
+    for tile_name in tile_names:
+        lockfile_name = os.path.join(datasource_root, 'cache', tile_name + '.lock')
+        locks.append(fasteners.InterProcessLock(lockfile_name))
 
-    @functools.wraps(wrapped)
-    def wrapper(path, *args, **kwargs):
-        lockfile_name = os.path.join(path, LOCKFILE_NAME)
-        with fasteners.try_lock(fasteners.InterProcessLock(lockfile_name)) as locked:
-            if not locked:
-                raise RuntimeError("Failed to lock cache %r." % path)
-            return wrapped(path, *args, **kwargs)
+    for lock in locks:
+        lock.acquire(blocking=True)
 
-    return wrapper
+    yield
+
+    for lock in locks:
+        lock.release()
 
 
-@folder_try_lock
+@contextmanager
+def lock_vrt(datasource_root, product):
+    with fasteners.InterProcessLock(os.path.join(datasource_root, product + '.vrt.lock')):
+        yield
+
+
 def ensure_setup(root, folders=(), file_templates=(), force=False, **kwargs):
-    created_folders = []
-    for path in [root] + [os.path.join(root, p) for p in folders]:
-        if not os.path.exists(path):
-            os.makedirs(path)
-            created_folders.append(path)
+    with fasteners.InterProcessLock(os.path.join(root, FOLDER_LOCKFILE_NAME)):
+        created_folders = []
+        for path in [root] + [os.path.join(root, p) for p in folders]:
+            if not os.path.exists(path):
+                os.makedirs(path)
+                created_folders.append(path)
 
-    created_files = collections.OrderedDict()
-    for relpath, template in collections.OrderedDict(file_templates).items():
-        path = os.path.join(root, relpath)
-        if force or not os.path.exists(path):
-            body = template.format(**kwargs)
-            with open(path, 'w') as file:
-                file.write(body)
-            created_files[path] = body
+        created_files = collections.OrderedDict()
+        for relpath, template in collections.OrderedDict(file_templates).items():
+            path = os.path.join(root, relpath)
+            if force or not os.path.exists(path):
+                body = template.format(**kwargs)
+                with open(path, 'w') as file:
+                    file.write(body)
+                created_files[path] = body
 
     return created_folders, created_files
 
 
-@folder_try_lock
 def check_call_make(path, targets=(), variables=()):
     make_targets = ' '.join(targets)
     variables_items = collections.OrderedDict(variables).items()

--- a/elevation/util.py
+++ b/elevation/util.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
-import functools
 import os
 import subprocess
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,7 +65,7 @@ def test_eio_clip(mocker, tmpdir):
     mocker.patch('subprocess.check_call')
     result = runner.invoke(cli.eio, options.split())
     assert not result.exception
-    assert subprocess.check_call.call_count == 3
+    assert subprocess.check_call.call_count == 4
 
     mocker.patch('subprocess.check_call')
     result = runner.invoke(cli.eio, ['clip'])

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import subprocess
-import re
 import pytest
 
 from elevation import datasource
@@ -45,7 +44,7 @@ def test_do_clip(mocker):
     bounds = (1, 5, 2, 6)
     mocker.patch('subprocess.check_call')
     cmd = datasource.do_clip(path='/tmp', bounds=bounds, output='/out.tif')
-    assert re.match(r'make -C /tmp clip OUTPUT="/out\.tif" PROJWIN="1 6 2 5" RUN_ID=".{32}"', cmd)
+    assert cmd.startswith('make -C /tmp clip OUTPUT="/out.tif" PROJWIN="1 6 2 5" RUN_ID="')
     subprocess.check_call.assert_called_with(cmd, shell=True)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,15 +18,15 @@ def test_selfcheck():
 
 
 def test_lock_tiles(tmpdir, mocker):
-    root = tmpdir.join('root')
-    with util.lock_tiles(str(root), ['a.tiff']):
+    root = str(tmpdir.join('root'))
+    with util.lock_tiles(root, ['a.tiff']):
         assert os.path.exists(os.path.join(root, 'cache', 'a.tiff.lock'))
 
 
 def test_lock_vrt(tmpdir, mocker):
-    root = tmpdir.join('root')
+    root = str(tmpdir.join('root'))
 
-    with util.lock_vrt(str(root), 'SRTM1'):
+    with util.lock_vrt(root, 'SRTM1'):
         assert os.path.exists(os.path.join(root, 'SRTM1.vrt.lock'))
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,14 +19,14 @@ def test_selfcheck():
 
 def test_lock_tiles(tmpdir, mocker):
     root = tmpdir.join('root')
-    with util.lock_tiles(root, ['a.tiff']):
+    with util.lock_tiles(str(root), ['a.tiff']):
         assert os.path.exists(os.path.join(root, 'cache', 'a.tiff.lock'))
 
 
 def test_lock_vrt(tmpdir, mocker):
     root = tmpdir.join('root')
 
-    with util.lock_vrt(root, 'SRTM1'):
+    with util.lock_vrt(str(root), 'SRTM1'):
         assert os.path.exists(os.path.join(root, 'SRTM1.vrt.lock'))
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,8 +7,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import subprocess
-
-import pytest
+import os
 
 from elevation import util
 
@@ -18,18 +17,17 @@ def test_selfcheck():
     assert 'NAME' in util.selfcheck([('NAME', 'false')])
 
 
-def test_folder_try_lock(tmpdir, mocker):
+def test_lock_tiles(tmpdir, mocker):
+    root = tmpdir.join('root')
+    with util.lock_tiles(root, ['a.tiff']):
+        assert os.path.exists(os.path.join(root, 'cache', 'a.tiff.lock'))
+
+
+def test_lock_vrt(tmpdir, mocker):
     root = tmpdir.join('root')
 
-    @util.folder_try_lock
-    def operation(path):
-        return True
-
-    assert operation(str(root))
-
-    mocker.patch('fasteners.InterProcessLock.acquire', return_value=False)
-    with pytest.raises(RuntimeError):
-        operation(str(root))
+    with util.lock_vrt(root, 'SRTM1'):
+        assert os.path.exists(os.path.join(root, 'SRTM1.vrt.lock'))
 
 
 def test_ensure_setup(tmpdir):


### PR DESCRIPTION
Previously, the locking mechanism was to lock the entire cache folder, and fail if another process had the lock. That means that only one eio instance was allowed to run at a time. Now, multiple eio instances can use the cache at the same time by using smarter locking.

Changes:

- Removed `try_lock` usage. That means that if a process fails to get a lock, it won't exit. It will wait until the lock is acquired.
- Only locking the whole folder with `ensure_setup`.
- When downloading tiles, each tile has its own lock, so if two processes are downloading different tiles, they are allowed to run concurrently.
- Added a special lock for the VRT, so two processes can't clash while writing the .vrt file.
- No locking when clipping. Multiple processes can make clips out of the .vrt at the same time.

**Is it safe?** I think so. The only way this could cause a race condition is if `gdalbuildvrt` makes multiple calls to `write` when writing the data to the .vrt file. Even if it does, the chance of having `gdal_translate` read the .vrt when some other process is writing to it is too small.