### PR TITLE
Added Ellipsoidal SRTM dataset

### DIFF
--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -78,13 +78,12 @@ def srtm_ellip_tiles_names(left, bottom, right, top,
     for ilon in range(ileft, iright + 1):
         slon = '%s%03d' % ('E' if ilon >= 0 else 'W', abs(ilon))
         for ilat in range(ibottom, itop + 1):
-            abs_ilat = abs(ilat)
-            slat = '%s%02d' % ('N' if abs_ilat >= 0 else 'S', abs_ilat)
-            subdir = 'North' if abs_ilat >= 0 else 'South'
+            slat = '%s%02d' % ('N' if ilat >= 0 else 'S', abs(ilat))
+            subdir = 'North' if ilat >= 0 else 'South'
             north_subdir = 'North_30_60' if ilat >= 30 else 'North_0_29'
             fname = tile_name_template.format(**locals())
 
-            if abs_ilat >= 0:
+            if ilat >= 0:
                 yield("{subdir}/{north_subdir}/{fname}".format(**locals()))
             else:
                 yield("{subdir}/{fname}".format(**locals()))

--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -70,7 +70,37 @@ def srtm3_tiles_names(left, bottom, right, top, tile_template='srtm_{ilon:02d}_{
             yield tile_template.format(**locals())
 
 
+def srtm_ellip_tiles_names(left, bottom, right, top,
+                           tile_name_template='{slat}{slon}_wgs84.tif'):
+    ileft, itop = srtm1_tile_ilonlat(left, top)
+    iright, ibottom = srtm1_tile_ilonlat(right, bottom)
+
+    for ilon in range(ileft, iright + 1):
+        slon = '%s%03d' % ('E' if ilon >= 0 else 'W', abs(ilon))
+        for ilat in range(ibottom, itop + 1):
+            abs_ilat = abs(ilat)
+            slat = '%s%02d' % ('N' if abs_ilat >= 0 else 'S', abs_ilat)
+            subdir = 'North' if abs_ilat >= 0 else 'South'
+            north_subdir = 'North_30_60' if ilat >= 30 else 'North_0_29'
+            fname = tile_name_template.format(**locals())
+
+            if abs_ilat >= 0:
+                yield(f"{subdir}/{north_subdir}/{fname}")
+            else:
+                yield(f"{subdir}/{fname}")
+
+
 DATASOURCE_MAKEFILE = pkgutil.get_data('elevation', 'datasource.mk').decode('utf-8')
+
+SRTM1_ELLIP_SPEC = {
+    'folders': ('spool', 'cache'),
+    'file_templates': {'Makefile': DATASOURCE_MAKEFILE},
+    'datasource_url': 'https://opentopography.s3.sdsc.edu/raster/SRTM_GL1_Ellip/SRTM_GL1_Ellip_srtm',
+    'tile_ext': '.tif',
+    'compressed_pre_ext': '',
+    'compressed_ext': '',
+    'tile_names': srtm_ellip_tiles_names,
+}
 
 SRTM1_SPEC = {
     'folders': ('spool', 'cache'),
@@ -95,6 +125,7 @@ SRTM3_SPEC = {
 PRODUCTS_SPECS = collections.OrderedDict([
     ('SRTM1', SRTM1_SPEC),
     ('SRTM3', SRTM3_SPEC),
+    ('SRTM1_ELLIP', SRTM1_ELLIP_SPEC),
 ])
 
 PRODUCTS = list(PRODUCTS_SPECS)

--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -85,9 +85,9 @@ def srtm_ellip_tiles_names(left, bottom, right, top,
             fname = tile_name_template.format(**locals())
 
             if abs_ilat >= 0:
-                yield(f"{subdir}/{north_subdir}/{fname}")
+                yield("{subdir}/{north_subdir}/{fname}".format(**locals()))
             else:
-                yield(f"{subdir}/{fname}")
+                yield("{subdir}/{fname}".format(**locals()))
 
 
 DATASOURCE_MAKEFILE = pkgutil.get_data('elevation', 'datasource.mk').decode('utf-8')

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -33,6 +33,16 @@ def test_srtm3_tiles_names():
     assert len(list(datasource.srtm3_tiles_names(9.9, 39.1, 15.1, 45.1))) == 9
 
 
+def test_srtm_ellip_tiles_names():
+    # Check the various subdirs in srtm_ellip
+    ds1 = ['North/North_30_60/N44E010_wgs84.tif']
+    ds2 = ['North/North_0_29/N07W074_wgs84.tif']
+    ds3 = ['South/S20E015_wgs84.tif']
+    assert list(datasource.srtm_ellip_tiles_names(10.1, 44.9, 10.1, 44.9)) == ds1
+    assert list(datasource.srtm_ellip_tiles_names(-73.99, 7.056, -73.90, 7.660)) == ds2
+    assert list(datasource.srtm_ellip_tiles_names(15.931, -19.194, 15.329, -19.961)) == ds3
+
+
 def test_ensure_tiles(mocker):
     mocker.patch('subprocess.check_call')
     cmd = datasource.ensure_tiles('/tmp', ['a', 'b'])


### PR DESCRIPTION
This PR adds new product `SRTM1_ELLIP` with the [opentopography](https://portal.opentopography.org/raster?opentopoID=OTSRTM.082016.4326.1) datasource containing height from ellipsoid which is useful for some kind of analysis.

Also added a test for the new function `srtm_ellip_tiles_names`, ran with `tox` and `python3.7` with no errors in sight. But did not test with the rest of interpreters:
```
 summary 
  docs: commands succeeded
  py27: commands succeeded
ERROR:  py34: InterpreterNotFound: python3.4
ERROR:  py35: InterpreterNotFound: python3.5
ERROR:  py36: InterpreterNotFound: python3.6
ERROR:  pypy: InterpreterNotFound: pypy
  qc: commands succeeded

```

Thanks for the `elevation` library, it has been very useful to me in the past so I'm more than happy to contribute :-D