### PR TITLE
fix issue #53: empty SRTM 3 file downloaded if the latitude is larger than 59

### DIFF
--- a/elevation/datasource.py
+++ b/elevation/datasource.py
@@ -73,7 +73,8 @@ def srtm3_tiles_names(left, bottom, right, top, tile_template='srtm_{ilon:02d}_{
     iright, ibottom = srtm3_tile_ilonlat(right, bottom)
     for ilon in range(ileft, iright + 1):
         for ilat in range(itop, ibottom + 1):
-            yield tile_template.format(**locals())
+            if ilon > 0 and ilat > 0:
+                yield tile_template.format(**locals())
 
 
 def srtm_ellip_tiles_names(left, bottom, right, top, tile_name_template='{slat}{slon}_wgs84.tif'):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -28,6 +28,7 @@ def test_srtm1_tiles_names():
 
 def test_srtm3_tiles_names():
     assert next(datasource.srtm3_tiles_names(10.1, 44.9, 10.1, 44.9)).endswith('srtm_39_04.tif')
+    assert next(datasource.srtm3_tiles_names(25.50, 58.40, 27.67, 60.06)).endswith('srtm_42_01.tif')
     assert len(list(datasource.srtm3_tiles_names(9.9, 39.1, 15.1, 45.1))) == 9
 
 


### PR DESCRIPTION
Added check for cases, when the tile indices have non-positive values.