### PR TITLE
Add option to suppress make output

### DIFF
--- a/elevation/util.py
+++ b/elevation/util.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 
 import fasteners
 
+SUPPRESS_OUTPUT = False
 FOLDER_LOCKFILE_NAME = '.folder_lock'
 
 
@@ -84,6 +85,9 @@ def check_call_make(path, targets=(), variables=()):
     make_targets = ' '.join(targets)
     variables_items = collections.OrderedDict(variables).items()
     make_variables = ' '.join('%s="%s"' % (k.upper(), v) for k, v in variables_items)
-    cmd = 'make -C {path} {make_targets} {make_variables}'.format(**locals())
+    cmd = 'make '
+    if SUPPRESS_OUTPUT:
+        cmd += '-s '
+    cmd += '-C {path} {make_targets} {make_variables}'.format(**locals())
     subprocess.check_call(cmd, shell=True)
     return cmd


### PR DESCRIPTION
This PR adds a flag in `elevation.util` called `SUPPRESS_OUTPUT`. By default this is set to `False`. However, if you wish to hide the commands make is printing, set it to `True`. e.g. 

```py
import elevation
import elevation.util
elevation.util.SUPPRESS_OUTPUT = True

elevation.clip(...)
```
